### PR TITLE
Agregar compatibilidad para usar Poncho como dependencia de NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "argob-poncho",
+  "version": "0.1.0",
+  "description": "Base de html y css para la creación de sitios pertenecientes a la Administración Pública Nacional de la República Argentina.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/argob/poncho.git"
+  },
+  "keywords": [
+    "bootstrap",
+    "gobierno",
+    "argentina",
+    "poncho",
+    "css"
+  ],
+  "author": "Presidencia de la Nación Argentina",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/argob/poncho/issues"
+  },
+  "homepage": "https://github.com/argob/poncho#readme"
+}


### PR DESCRIPTION
Para poder requerir Poncho como una dependencia de [NPM](npmjs.com).