### PR TITLE
AABE margenes fitro mobile

### DIFF
--- a/src/scss/modules/aabe/_aabe.scss
+++ b/src/scss/modules/aabe/_aabe.scss
@@ -242,6 +242,16 @@
   .node-type-subasta .ar-details__content {
     padding: 0!important
     }
+
+    /* Ajustes de filtros: se eliminan márgenes internos */
+    .filtro {
+    .form-item-tipo-proyecto,
+    .form-group.m-t-05,
+    .form-item-order-by label {
+      margin: 0 !important;
+    }
+  }
+    
 }
 
 /* ESTILOS BASE Y UTILIDADES */


### PR DESCRIPTION
Ajustes de estilos en mobile (<768px): se eliminan márgenes en campos de filtros (tipo de proyecto, orden y grupo) para compactar el formulario

https://proyectos.argentina.gob.ar/issues/17221#note-16